### PR TITLE
Update CMake requirement to 4.0.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Please ensure that any changes remain compliant with 3.1.
+# Updated to require CMake 4.0.3
 if(NOT EMBED_OPENBABEL)
-  cmake_minimum_required(VERSION 3.1)
+  cmake_minimum_required(VERSION 4.0.3)
 endif()
 
 project(openbabel)

--- a/doc/examples/static_executable/CMakeLists.txt
+++ b/doc/examples/static_executable/CMakeLists.txt
@@ -25,7 +25,7 @@
 #
 
 # This line is required for cmake backwards compatibility.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 4.0.3)
 
 # Name of your project
 project(myproject)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.0)
+cmake_minimum_required(VERSION 4.0.3)
 # Library versioning (used in Mac Python bindings)x
 set(SOVERSION 4)
 

--- a/src/doxygen_pages.cpp
+++ b/src/doxygen_pages.cpp
@@ -36,7 +36,7 @@ namespace OpenBabel {
  * @b CMakeLists.txt
  * @code
 # this line is required for cmake backwards compatibility
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 4.0.3)
 
 # name of your project
 project(myproject)


### PR DESCRIPTION
## Summary
- require CMake 4.0.3 throughout

## Testing
- `cmake -S . -B build` *(fails: CMake 4.0.3 or higher is required)*

------
https://chatgpt.com/codex/tasks/task_e_68517f15311483338d01b0aab5e0e014