### PR TITLE
Fix CMake policy CMP0042

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set (CMAKE_CXX_STANDARD 11)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
   if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 OLD)
+    cmake_policy(SET CMP0042 NEW)
   endif()
 endif()
 


### PR DESCRIPTION
## Summary
- update CMP0042 setting to `NEW`

## Testing
- `cmake .. -DMINIMAL_BUILD=ON` *(fails: Boost and other deps missing)*
- `make -j2` *(fails: build interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68518e78c43083338ecb5505b7d8326b