### PR TITLE
Fix ZLIB linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set (CMAKE_CXX_STANDARD 11)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
   if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 OLD)
+    cmake_policy(SET CMP0042 NEW)
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,8 +220,8 @@ set(openbabel_library_srcs
 
 if(WIN32)
   if(ZLIB_FOUND)
-    set(libs ${libs} ${ZLIB_LIBRARY})
-  endif(ZLIB_FOUND)
+    set(libs ${libs} ZLIB::ZLIB)
+  endif()
 else(WIN32)
   # the C math library
   if(BUILD_MIXED)
@@ -242,8 +242,8 @@ else(WIN32)
   endif(BUILD_SHARED)
 
   if(ZLIB_FOUND)
-    set(libs ${libs} ${ZLIB_LIBRARY})
-  endif(ZLIB_FOUND)
+    set(libs ${libs} ZLIB::ZLIB)
+  endif()
 endif(WIN32)
 
 add_library(openbabel ${BUILD_TYPE}


### PR DESCRIPTION
## Summary
- set policy CMP0042 to NEW
- link using imported ZLIB::ZLIB target to avoid missing library

## Testing
- `cmake .. -DMINIMAL_BUILD=ON`
- `cmake --build . -j2` *(fails: build interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68518e78c43083338ecb5505b7d8326b