### PR TITLE
Retry aromatic backtracking and add kekulization test

### DIFF
--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -357,29 +357,46 @@ namespace OpenBabel
     // not on Linux. Removing the premature exit ensures every augmenting
     // path opportunity is explored, trading a handful of extra loop
     // iterations for eliminating false "not kekulizable" outcomes.
-    int idx;
-    for (idx = needs_dbl_bond->FirstBit(); idx != needs_dbl_bond->EndBit(); idx = needs_dbl_bond->NextBit(idx)) {
-      // Our goal is to find an alternating path to another atom
-      // that needs a double bond
-      needs_dbl_bond->SetBitOff(idx); // to avoid the trivial null path being found
-      OBBitVec visited(atomArraySize);
-      m_path.clear();
-      bool found_path = FindPath(idx, false, visited);
-      if (!found_path) { // could only happen if not kekulizable
-        needs_dbl_bond->SetBitOn(idx); // reset
-        continue;
+
+    // The augmented matching built during a pass over the unmatched atoms
+    // can unlock new paths for atoms visited earlier in that same pass.
+    // Iterate until either all atoms have been matched or an entire pass
+    // fails to add any new double bonds.
+    bool matchedInPass = false;
+    do {
+      matchedInPass = false;
+      std::vector<int> unmatched;
+      for (int idx = needs_dbl_bond->FirstBit(); idx != needs_dbl_bond->EndBit(); idx = needs_dbl_bond->NextBit(idx)) {
+        unmatched.push_back(idx);
       }
-      m_path.push_back(idx);
-      needs_dbl_bond->SetBitOff(m_path[0]);
-      // Flip all of the bond orders on the path from double<-->single
-      for (unsigned int i = 0; i < m_path.size()-1; ++i) {
-        OBBond *bond = m_mol->GetBond(m_path[i], m_path[i + 1]);
-        if (i % 2 == 0)
-          doubleBonds->SetBitOn(bond->GetIdx());
-        else
-          doubleBonds->SetBitOff(bond->GetIdx());
+
+      for (int idx : unmatched) {
+        if (!needs_dbl_bond->BitIsSet(idx))
+          continue;
+        // Our goal is to find an alternating path to another atom
+        // that needs a double bond
+        needs_dbl_bond->SetBitOff(idx); // to avoid the trivial null path being found
+        OBBitVec visited(atomArraySize);
+        m_path.clear();
+        bool found_path = FindPath(idx, false, visited);
+        if (!found_path) { // could only happen if not kekulizable
+          needs_dbl_bond->SetBitOn(idx); // reset
+          continue;
+        }
+        m_path.push_back(idx);
+        needs_dbl_bond->SetBitOff(m_path[0]);
+        // Flip all of the bond orders on the path from double<-->single
+        for (unsigned int i = 0; i < m_path.size()-1; ++i) {
+          OBBond *bond = m_mol->GetBond(m_path[i], m_path[i + 1]);
+          if (i % 2 == 0)
+            doubleBonds->SetBitOn(bond->GetIdx());
+          else
+            doubleBonds->SetBitOff(bond->GetIdx());
+        }
+        matchedInPass = true;
       }
-    }
+    } while (matchedInPass && !needs_dbl_bond->IsEmpty());
+
     return needs_dbl_bond->IsEmpty();
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ add_definitions(-DFORMATDIR="${FORMATDIR}/")
 set(cpptests
   alias automorphism builder canonconsistent canonfragment canonstable carspacegroup cifspacegroup
   cistrans conversion graphsym gzip addh
-  implicitH lssr isomorphism multicml periodic regressions rotor shuffle smiles spectrophore
+  implicitH kekulize lssr isomorphism multicml periodic regressions rotor shuffle smiles spectrophore
   squareplanar stereo stereoperception tautomer tetrahedral
   tetranonplanar tetraplanar uniqueid
 )

--- a/test/kekulizetest.cpp
+++ b/test/kekulizetest.cpp
@@ -1,0 +1,62 @@
+/**********************************************************************
+kekulizetest.cpp - Regression tests for aromatic kekulization
+
+Copyright (C) 2025 Open Babel contributors
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************/
+
+// used to set import/export for Cygwin DLLs
+#ifdef WIN32
+#define USING_OBDLL
+#endif
+
+#include "obtest.h"
+
+#include <openbabel/kekulize.h>
+#include <openbabel/obconversion.h>
+
+#include <string>
+#include <vector>
+
+using namespace std;
+using namespace OpenBabel;
+
+static bool KekulizeFromSmiles(const std::string &smiles)
+{
+  OBMol mol;
+  OBConversion conv;
+
+  OB_REQUIRE(conv.SetInFormat("smi"));
+  OB_REQUIRE(conv.ReadString(&mol, smiles));
+
+  return OBKekulize(&mol);
+}
+
+int kekulizetest(int argc, char *argv[])
+{
+  cout << endl << "# Testing aromatic kekulization stability...  " << endl;
+
+  vector<string> aromaticSmiles = {
+      "c1ccccc1",
+      "c1ccccc1N",
+      "Cc1ccccc1",
+  };
+
+  for (const string &smiles : aromaticSmiles) {
+    OB_ASSERT(KekulizeFromSmiles(smiles));
+  }
+
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- repeat aromatic backtracking passes so augmenting paths found after earlier matches
- add a regression test covering common aromatic SMILES kekulization
- wire the new test into the C++ test suite

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69359d5c38188333980d0ef3d31ce7b5)