### PR TITLE
Prevent OBMessageHandler double-free during teardown (teardown guard + obLogBuf fix)

### DIFF
--- a/include/openbabel/oberror.h
+++ b/include/openbabel/oberror.h
@@ -161,6 +161,8 @@ namespace OpenBabel
       unsigned int GetDebugMessageCount() { return _messageCount[obDebug];}
       //! \return Summary of messages received at all levels
       std::string GetMessageSummary();
+      //! \return whether this handler is currently being destroyed
+      bool IsDestructing() const { return _isDestructing; }
 
     protected:
       //! Log of messages for later retrieval via GetMessagesOfLevel()
@@ -176,6 +178,8 @@ namespace OpenBabel
       bool                   _logging;
       //! The maximum size of _messageList log
       unsigned int           _maxEntries;
+      //! True while this handler is being destroyed; suppresses teardown logging
+      bool                   _isDestructing;
 
       //! The default stream buffer for the output stream (saved if wrapping is ued)
       std::streambuf        *_inWrapStreamBuf;
@@ -208,7 +212,8 @@ namespace OpenBabel
       //! Call OBMessageHandler::ThrowError() and flush the buffer
       int sync()
         {
-          obErrorLog.ThrowError("", str(), obInfo);
+          if (!obErrorLog.IsDestructing())
+            obErrorLog.ThrowError("", str(), obInfo);
           str(std::string()); // clear the buffer
           return 0;
         }

--- a/src/oberror.cpp
+++ b/src/oberror.cpp
@@ -143,7 +143,8 @@ namespace OpenBabel
   **/
 
   OBMessageHandler::OBMessageHandler() :
-    _outputLevel(obWarning), _outputStream(&clog), _logging(true), _maxEntries(100)
+    _outputLevel(obWarning), _outputStream(&clog), _logging(true), _maxEntries(100),
+    _isDestructing(false)
   {
     _messageCount[0] = _messageCount[1] = _messageCount[2] = 0;
     _messageCount[3] = _messageCount[4] = 0;
@@ -153,6 +154,7 @@ namespace OpenBabel
 
   OBMessageHandler::~OBMessageHandler()
   {
+    _isDestructing = true;
     StopErrorWrap();
 
     // free the internal filter streambuf
@@ -161,6 +163,9 @@ namespace OpenBabel
 
   void OBMessageHandler::ThrowError(OBError err, errorQualifier qualifier)
   {
+    if (_isDestructing)
+      return;
+
     if (!_logging)
       return;
 
@@ -181,6 +186,9 @@ namespace OpenBabel
                                     const std::string &errorMsg,
                                     obMessageLevel level, errorQualifier qualifier)
   {
+    if (_isDestructing)
+      return;
+
     if (errorMsg.length() > 1)
       {
         OBError err(method, errorMsg, "", "", "", level);
@@ -213,7 +221,7 @@ namespace OpenBabel
 
     if (_filterStreamBuf == nullptr)
       {
-        _filterStreamBuf = new(obLogBuf);
+        _filterStreamBuf = new obLogBuf;
       }
 
     cerr.rdbuf(_filterStreamBuf);


### PR DESCRIPTION
### Motivation
- A crash during global library teardown was traced to `obLogBuf::~obLogBuf()` calling `obErrorLog.ThrowError()` while the global `obErrorLog` was itself being destroyed, causing heap corruption. 
- The code also used malformed placement-new syntax when allocating the internal `obLogBuf`, which is confusing and potentially incorrect.

### Description
- Added a protected `_isDestructing` flag to `OBMessageHandler` with a read accessor `IsDestructing()` to indicate when the global handler is being torn down. 
- Initialize `_isDestructing` to `false` in the constructor and set it to `true` at the start of `~OBMessageHandler()` so teardown code can avoid re-entrancy. 
- Made both overloads of `OBMessageHandler::ThrowError()` return immediately when `_isDestructing` is set, preventing modifications to internal containers during global destruction. 
- Guarded `obLogBuf::sync()` so it clears the buffer but does not call `obErrorLog.ThrowError()` when the handler is destructing. 
- Replaced the malformed `new(obLogBuf)` placement-new usage with `new obLogBuf` in `StartErrorWrap()`.

### Testing
- Configured the project with `cmake -S . -B build -DBUILD_TESTING=ON` and the configuration step completed successfully. 
- Built the library with `cmake --build build --target openbabel -- -j2` and the build completed successfully. 
- Compiled and ran a small smoke test program that calls `obErrorLog.StartErrorWrap()` and writes to `std::cerr`; the program exited cleanly with no teardown crash. 
- Ran `ctest --test-dir build --output-on-failure -R error`, which completed but reported no matching tests (no failures encountered during the above steps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60c0edf41883339d18165d82c96a75)