### PR TITLE
Avoid OBMessageHandler stream access during global teardown

### DIFF
--- a/include/openbabel/oberror.h
+++ b/include/openbabel/oberror.h
@@ -212,8 +212,10 @@ namespace OpenBabel
       //! Call OBMessageHandler::ThrowError() and flush the buffer
       int sync()
         {
-          if (!obErrorLog.IsDestructing())
-            obErrorLog.ThrowError("", str(), obInfo);
+          if (obErrorLog.IsDestructing())
+            return 0;
+
+          obErrorLog.ThrowError("", str(), obInfo);
           str(std::string()); // clear the buffer
           return 0;
         }

--- a/src/oberror.cpp
+++ b/src/oberror.cpp
@@ -158,7 +158,8 @@ namespace OpenBabel
     StopErrorWrap();
 
     // free the internal filter streambuf
-    delete _filterStreamBuf;
+    if (_filterStreamBuf)
+      delete _filterStreamBuf;
   }
 
   void OBMessageHandler::ThrowError(OBError err, errorQualifier qualifier)
@@ -233,7 +234,8 @@ namespace OpenBabel
     if (_inWrapStreamBuf == nullptr)
       return true; // never wrapped cerr
 
-    cerr.rdbuf(_inWrapStreamBuf);
+    if (!_isDestructing)
+      cerr.rdbuf(_inWrapStreamBuf);
     _inWrapStreamBuf = nullptr; //shows not wrapped
 
     // don't delete the filter streambuf yet -- we might start wrapping later


### PR DESCRIPTION
### Motivation
- A crash (double free / heap corruption) was observed during global teardown when `~OBMessageHandler()` manipulates `std::cerr` or string internals while global iostreams or allocators may already be torn down.
- Existing `_isDestructing` guard prevented `ThrowError()` but teardown still performed `cerr.rdbuf(...)` and unconditional `str(std::string())`, which can touch torn-down global state and corrupt memory.

### Description
- In `include/openbabel/oberror.h` changed `obLogBuf::sync()` to return immediately when `obErrorLog.IsDestructing()` to skip all sync work during destruction.
- In `src/oberror.cpp` changed `OBMessageHandler::StopErrorWrap()` to only call `cerr.rdbuf(_inWrapStreamBuf)` when `!_isDestructing` to avoid touching `std::cerr` during global teardown.
- In `src/oberror.cpp` made deletion of `_filterStreamBuf` explicit by null-checking before `delete` in `OBMessageHandler::~OBMessageHandler()`.

### Testing
- Ran configuration with `cmake -S . -B build -DBUILD_TESTING=ON -DRUN_SWIG=OFF`, which completed successfully.
- Built the library with `cmake --build build --target openbabel -j2`, which succeeded and produced `libopenbabel.so` without errors.
- Ran `git diff --check` to validate whitespace/diff issues and it reported no problems.
- An attempt to build `test_obconversion` failed because that build target does not exist in this configuration (reported as not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60d1e84f24833399dddc4d6713e421)